### PR TITLE
docs: update README to clarify plugin registration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 A shorthand for binding prop with the same data name for JSX. Powered by [ast-grep](https://github.com/ast-grep/ast-grep).
 
+
 ```tsx
 export default () => {
   const [value, setValue] = useState()
@@ -23,6 +24,16 @@ export default () => {
 
 ```bash
 npm i -D unplugin-jsx-short-bind
+```
+> Note: While registering the plugin in your config files, always have the plugin before the framework's main plugin. Otherwise, you'll get parse errors; For example:
+```ts 
+// vite.config.js
+import { react } from '@vite/plugin-react';
+import JsxShortBind from "unplugin-jsx-short-bind/vite";
+
+export default defineConfig({
+  plugins: [JsxShortBind(), react()],
+});
 ```
 
 <details>


### PR DESCRIPTION
Hello, we had a discussion in the [facebook/jsx](https://github.com/facebook/jsx/issues/164#issuecomment-2782776886) repo

I have used the plugin in a React app and it has worked wonderfully. 

Mine is just a small addition on the docs, I made a mistake of including the plugin after the react() plugin which made me have parse errors. Might help other devs too.

Again, awesome work and I'd be happy to contribute when needed.