### PR TITLE
docs: fixed the react import code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ npm i -D unplugin-jsx-short-bind
 ```
 > Note: While registering the plugin in your config files, always have the plugin before the framework's main plugin. Otherwise, you'll get parse errors; For example:
 ```ts
-// vite.config.js
-import { react } from '@vite/plugin-react';
+// vite.config.ts
+import react from '@vitejs/plugin-react';
 import JsxShortBind from "unplugin-jsx-short-bind/vite";
 
 export default defineConfig({


### PR DESCRIPTION
I had made a slight error in the docs, have changed it now.


And also, I wouldn't mind your help on a problem I am having, I have created my babel-plugin with my custom parser and I'm using Vite as my bundler but when building, the dist/index.js file doesn't contain the plugin's exported function.(It's like it bundles the babel-parser and then it stops there - this is what I am speculating so not exactly sure)

I have also added the custom-parser to my codebase to make it easier to use, however, it affects the final bundle size even without the plugin function

Here's the repo: [Babel-Plugin-JSX-Prop-Shorthand](https://github.com/KWangechi/babel-plugin-transform-react-jsx-prop-shorthand)

I would really appreciate your help.

It's not perfect, this is the first time I am building a plugin so forgive my slopiness